### PR TITLE
Allow for chef search queries, which require query parameters in the URI

### DIFF
--- a/application/libraries/chef.php
+++ b/application/libraries/chef.php
@@ -116,10 +116,11 @@ class chef {
 
         // check if endpoint is full url
         $parts = parse_url($endpoint);
-        if (isset($parts['host']))
+
+        if (isset($parts['path']))
         {
             // split server and endpoint
-            $endpoint = $parts['path'];
+            $endpoint = '/' . ltrim($parts['path'], '/');
             $url = $this->server . $endpoint;
         }
         else
@@ -130,9 +131,9 @@ class chef {
         }
 
         // append data to url if GET request
-        if ($method == 'GET' && is_array($data))
+        if ($method == 'GET' && isset($parts['query']))
         {
-            $url .= '?' . http_build_query($data);
+            $url .= '?' . $parts['query'];
             $data = FALSE;
         }
 
@@ -279,10 +280,10 @@ class chef {
         $timestamp = gmdate("Y-m-d\TH:i:s\Z");
 
         // add X-Ops headers
-        $header[] = 'X-Ops-Sign: algorithm=sha1;version=1.0';
-        $header[] = 'X-Ops-UserId: ' . $this->client;
-        $header[] = 'X-Ops-Timestamp: ' . $timestamp;
-        $header[] = 'X-Ops-Content-Hash: ' . base64_encode(sha1($data, true));
+        $header[] = 'X-Ops-Sign:version=1.0';
+        $header[] = 'X-Ops-UserId:' . $this->client;
+        $header[] = 'X-Ops-Timestamp:' . $timestamp;
+        $header[] = 'X-Ops-Content-Hash:' . base64_encode(sha1($data, true));
 
         //rewrite the endpoint for enterprise organizations
         if ($this->enterprise_org !== false)


### PR DESCRIPTION
e.g. $this->chef->get('/search/node?q=role:myrole');

Change is to allow key=value pairs in the URI that is passed to the ->get method, instead of requiring GET parameters to be passed in via the 3rd $data parameter.  

This was failing with chef searches because passing in the $data array('q' => 'role:myrole') was running http_build_query() against the value and encoding the colon, causing the URI to be /search/node?q=role%3Amyrole.  This was causing the X-Ops-Content-Hash to encode the encoded value, and not the decoded colon, and the request gets rejected by the chef server because role:myrole != role%3Amyrole

Additional small change to remove the spaces in the X-Ops headers.  I also removed the "algorithm=sha1;" value in the X-Ops-Sign header per the documentation:
X-Ops-Sign  Set this header to the following value: version=1.0.
